### PR TITLE
Optimizations to Schlinkert algorithm, up to -87.5% reduction

### DIFF
--- a/src/schlinkert.rs
+++ b/src/schlinkert.rs
@@ -9,75 +9,51 @@ use std::collections::HashSet;
 
 /// Return true if the list is uniquely decodable, false if not. I
 /// don't _think_ we need to check reversed words in this case.
-pub fn is_uniquely_decodable(c: &[String]) -> bool {
-    let c = vec_to_hash(c);
-    sardinas_patterson_theorem(c)
-}
-
-fn vec_to_hash(v: &[String]) -> HashSet<String> {
-    let mut my_hash = HashSet::new();
-    for e in v {
-        my_hash.insert(e.to_string());
-    }
-    my_hash
+pub fn is_uniquely_decodable<T: AsRef<str>>(c: &[T]) -> bool {
+    sardinas_patterson_theorem(c.iter().map(|f| f.as_ref()).collect())
 }
 
 // Generate c for any number n
-fn generate_cn(c: &HashSet<String>, n: usize) -> HashSet<String> {
-    if n == 0 {
-        return c.to_owned();
-    } else {
-        let mut cn = HashSet::new();
+fn generate_cn<'a>(c: &HashSet<&'a str>, cn_minus_1: &HashSet<&'a str>) -> HashSet<&'a str> {
+    let mut cn = HashSet::new();
 
-        // generate c_(n-1)
-        let cn_minus_1 = generate_cn(c, n - 1);
-        for w1 in c.iter() {
-            for w2 in cn_minus_1.iter() {
-                if w1.len() > w2.len() && w1.starts_with(w2) {
-                    // w2 is a prefix word of w1
-                    // so, we're going to add the dangling suffix to a new HashSet
-                    // called cn
-                    cn.insert(w1[w2.len()..].to_string());
-                }
+    for w1 in c.iter() {
+        for w2 in cn_minus_1.iter() {
+            if w1.len() > w2.len() && w1.starts_with(w2) {
+                // w2 is a prefix word of w1
+                // so, we're going to add the dangling suffix to a new HashSet
+                // called cn
+                cn.insert(&w1[w2.len()..]);
+            }
+            if w2.len() > w1.len() && w2.starts_with(w1) {
+                // w1 is a prefix word of w2
+                // so, we're going to add the dangling suffix to a new HashSet
+                // called cn
+                cn.insert(&w2[w1.len()..]);
             }
         }
-        // Now the other way? Could we clean this up?
-        for w1 in cn_minus_1.iter() {
-            for w2 in c.iter() {
-                if w1.len() > w2.len() && w1.starts_with(w2) {
-                    // w2 is a prefix word of w1
-                    // so, we're going to add the dangling suffix to a new HashSet
-                    // called cn
-                    cn.insert(w1[w2.len()..].to_string());
-                }
-            }
-        }
-        cn
     }
+    cn
 }
 
-fn generate_c_infinity_with_a_halt_break(c: HashSet<String>) -> HashSet<String> {
-    let mut cs = HashSet::new();
-    let mut c_infinity = HashSet::new();
-    let mut n = 1;
-    let mut cn = generate_cn(&c, n);
+fn generate_c_infinity_with_a_halt_break<'a>(c: &'a HashSet<&str>) -> HashSet<&'a str> {
+    let mut cn = generate_cn(c, c);
+    let mut cs = cn.clone();
 
-    while !cn.is_empty() {
-        if cn.is_subset(&cs) {
+    loop {
+        cn = generate_cn(c, &cn);
+        let prior = cs.len();
+        cs.extend(&cn);
+        if cs.len() == prior { // if the set size did not increase, cn is a subset
             // Cycle detected. Halting algorithm.
             break;
-        } else {
-            cs = cs.union(&cn).map(|e| e.to_string()).collect();
-            c_infinity = c_infinity.union(&cn).map(|e| e.to_string()).collect();
-            n += 1;
-            cn = generate_cn(&c, n);
         }
     }
-    c_infinity
+    cs
 }
 
 /// Returns true if c is uniquely decodable
-fn sardinas_patterson_theorem(c: HashSet<String>) -> bool {
-    let c_infinity = generate_c_infinity_with_a_halt_break(c.clone());
+fn sardinas_patterson_theorem(c: HashSet<&str>) -> bool {
+    let c_infinity = generate_c_infinity_with_a_halt_break(&c);
     c.is_disjoint(&c_infinity)
 }


### PR DESCRIPTION
- No clone/to_owned
- Combined loops
- No repeated calls to `generate_cn` with the same `n`. Removed duplicate work. This was the largest single benefit.

cargo bench
===
```
     Running benches/long_not_ud_list.rs (target/release/deps/long_not_ud_list-f027967d24d31a17)
Gnuplot not found, using plotters backend
Benchmarking Check long, not UD list/Schlinkert: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 47.2s.
Check long, not UD list/Schlinkert
                        time:   [4.6974 s 4.7713 s 4.8589 s]
                        change: [-83.954% -83.690% -83.388%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 10 measurements (20.00%)
  2 (20.00%) high mild

     Running benches/long_ud_list.rs (target/release/deps/long_ud_list-3022173e81445c0e)
Gnuplot not found, using plotters backend
Benchmarking Check long, UD list/Schlinkert: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 71.2s.
Check long, UD list/Schlinkert
                        time:   [7.0938 s 7.1845 s 7.3075 s]
                        change: [-87.711% -87.545% -87.338%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 10 measurements (20.00%)
  2 (20.00%) high severe

     Running benches/medium_list.rs (target/release/deps/medium_list-59159e0384472fee)
Gnuplot not found, using plotters backend
Benchmarking Check medium, not UD list/Schlinkert: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 8.2s or enable flat sampling.
Check medium, not UD list/Schlinkert
                        time:   [148.75 ms 155.88 ms 164.69 ms]
                        change: [-75.701% -74.607% -73.357%] (p = 0.00 < 0.10)
                        Performance has improved.
Found 2 outliers among 10 measurements (20.00%)
  2 (20.00%) high mild

     Running benches/short_list.rs (target/release/deps/short_list-51c6e1773d8596ab)
Gnuplot not found, using plotters backend
Check short UD list/Schlinkert
                        time:   [977.15 µs 979.91 µs 982.85 µs]
                        change: [-24.010% -23.716% -23.425%] (p = 0.00 < 0.10)
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  5 (5.00%) low mild
  5 (5.00%) high mild
  2 (2.00%) high severe

