### PR TITLE
Finish `dashmap::DashSet` refactor

### DIFF
--- a/src/schlinkert.rs
+++ b/src/schlinkert.rs
@@ -10,22 +10,22 @@ use dashmap::DashSet;
 /// Return true if the list is uniquely decodable, false if not. I
 /// don't _think_ we need to check reversed words in this case.
 pub fn is_uniquely_decodable<T: AsRef<str>>(c: &[T]) -> bool {
-    sardinas_patterson_theorem(c.iter().map(|f| f.as_ref()).collect())
+    sardinas_patterson_theorem(&c.iter().map(|f| f.as_ref()).collect())
 }
 
 /// Generate c for any number n
 fn generate_cn<'a>(c: &DashSet<&'a str>, cn_minus_1: &DashSet<&'a str>) -> DashSet<&'a str> {
-    let mut cn = DashSet::new();
+    let cn = DashSet::new();
 
     for w1 in c.iter() {
         for w2 in cn_minus_1.iter() {
-            if w1.len() > w2.len() && w1.starts_with(w2) {
+            if w1.len() > w2.len() && w1.starts_with(*w2) {
                 // w2 is a prefix word of w1
                 // so, we're going to add the dangling suffix to a new DashSet
                 // called cn
                 cn.insert(&w1[w2.len()..]);
             }
-            if w2.len() > w1.len() && w2.starts_with(w1) {
+            if w2.len() > w1.len() && w2.starts_with(*w1) {
                 // w1 is a prefix word of w2
                 // so, we're going to add the dangling suffix to a new DashSet
                 // called cn
@@ -36,14 +36,14 @@ fn generate_cn<'a>(c: &DashSet<&'a str>, cn_minus_1: &DashSet<&'a str>) -> DashS
     cn
 }
 
-fn generate_c_infinity_with_a_halt_break<'a>(c: &'a DashSet<&str>) -> DashSet<&'a str> {
+fn generate_c_infinity_with_a_halt_break<'a>(c: &DashSet<&'a str>) -> DashSet<&'a str> {
     let mut cn = generate_cn(c, c);
     let mut cs = cn.clone();
 
     loop {
         cn = generate_cn(c, &cn);
         let prior = cs.len();
-        cs.extend(&cn);
+        cs.extend(cn.iter().map(|s| *s));
         if cs.len() == prior {
             // if the set size did not increase, cn is a subset
             // Cycle detected. Halting algorithm.
@@ -54,7 +54,11 @@ fn generate_c_infinity_with_a_halt_break<'a>(c: &'a DashSet<&str>) -> DashSet<&'
 }
 
 /// Returns true if c is uniquely decodable
-fn sardinas_patterson_theorem(c: DashSet<&str>) -> bool {
-    let c_infinity = generate_c_infinity_with_a_halt_break(&c);
-    c.is_disjoint(&c_infinity)
+fn sardinas_patterson_theorem(c: &DashSet<&str>) -> bool {
+    let c_infinity = generate_c_infinity_with_a_halt_break(c);
+    if c.len() <= c_infinity.len() {
+        c.iter().all(|v| !c_infinity.contains(*v))
+    } else {
+        c_infinity.iter().all(|v| !c.contains(*v))
+    }
 }


### PR DESCRIPTION
Barely anything changed, there's just some reference nesting and lifetime signature fixes and since `is_disjointed` isn't implemented for DashSet, [adding the rather simple implementation](https://doc.rust-lang.org/src/std/collections/hash/set.rs.html#810-816) here isn't that bad I think.