### PR TITLE
Allow benchmark saving

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,21 @@ harness = false
 [[bench]]
 name = "long_not_ud_list"
 harness = false
+
+[lib]
+bench = false
+
+[[bin]]
+name = "uniquely_decodable"
+path = "src/main.rs"
+bench = false
+
+[[bin]]
+name = "colfenor_rodeh"
+path = "src/bin/colfenor_rodeh.rs"
+bench = false
+
+[[bin]]
+name = "schlinkert"
+path = "src/bin/schlinkert.rs"
+bench = false


### PR DESCRIPTION
With this change you can save benchmark baselines with names:

```shell
cargo bench -- --save-baseline main
```

Here with the name `main`

Then use them like so:

```shell
cargo bench -- --baseline main
```

This lets you always compare to a known point rather than just the last run.